### PR TITLE
[Telink]: Adapt HAL drivers for Matter project

### DIFF
--- a/tlsr9/common/types.h
+++ b/tlsr9/common/types.h
@@ -51,17 +51,24 @@
 typedef unsigned char u8 ;
 typedef unsigned short u16 ;
 typedef unsigned int u32 ;
+typedef unsigned long long u64 ;
 typedef signed char s8 ;
 typedef signed short s16 ;
 typedef signed int s32 ;
+typedef signed long long s64 ;
+
+#ifndef _Bool
 typedef enum
 {
 	false,
 	true
 }bool;
+#endif
 
 #ifdef __GNUC__
+#ifndef __WCHAR_TYPE__
 typedef	unsigned short	wchar_t;
+#endif
 #endif
 
 

--- a/tlsr9/drivers/B91/aes.c
+++ b/tlsr9/drivers/B91/aes.c
@@ -61,7 +61,7 @@
 /**********************************************************************************************************************
  *                                              global variable                                                       *
  *********************************************************************************************************************/
-_attribute_aes_data_sec_ unsigned int aes_data_buff[8];
+_attribute_aes_data_sec_ static unsigned int aes_data_buff[8];
 unsigned int aes_base_addr = 0xc0000000;
 /**********************************************************************************************************************
  *                                              local variable                                                     *
@@ -175,4 +175,14 @@ static inline void aes_wait_done(void)
 {
 	while(FLD_AES_START == (reg_aes_mode & FLD_AES_START));
 }
+
+/**
+ * @brief     This function is a getter for aes_data_buff
+ * @return    pointer to aes_data_buff.
+ */
+unsigned int * aes_data_buff_ptr_get(void)
+{
+    return aes_data_buff;
+}
+
 

--- a/tlsr9/drivers/B91/aes.h
+++ b/tlsr9/drivers/B91/aes.h
@@ -171,4 +171,10 @@ static inline void aes_clr_irq_status(aes_irq_e status)
 	reg_aes_clr_irq_status = (status);
 }
 
+/**
+ * @brief     This function is a getter for aes_data_buff
+ * @return    pointer to aes_data_buff.
+ */
+unsigned int * aes_data_buff_ptr_get(void);
+
 #endif /* _AES_H_ */

--- a/tlsr9/drivers/B91/pm.c
+++ b/tlsr9/drivers/B91/pm.c
@@ -291,6 +291,29 @@ void pm_update_32k_rc_sleep_tick (unsigned int tick_32k, unsigned int tick)
 }
 
 /**
+ * @brief		Calculate the offset value based on the difference of 16M tick.
+ * @param[in]	offset_tick	- the 16M tick difference between the standard clock and the expected clock.
+ * @return		none.
+ */
+void pm_cal_32k_rc_offset (int offset_tick)
+{
+	pmcd.offset_cur = offset_tick;
+	int offset = offset_tick * (240 * 31) / pmcd.rc32;		//240ms / sleep_period
+	if (offset > 0x100)
+	{
+		offset = 0x100;
+	}
+	else if (offset < -0x100)
+	{
+		offset = -0x100;
+	}
+	pmcd.calib = 1;
+	pmcd.offset += (offset - pmcd.offset) >> 4;
+	pmcd.offset_dc += (offset_tick - pmcd.offset_dc) >> 3;
+	g_pm_tick_update_en = 0;
+}
+
+/**
  * @brief		32k rc calibration clock compensation.
  * @return		32k calibration value after compensation.
  */

--- a/tlsr9/drivers/B91/rf.h
+++ b/tlsr9/drivers/B91/rf.h
@@ -672,6 +672,11 @@ void rf_set_ble_2M_NO_PN_mode(void);
  */
 void rf_set_ble_500K_mode(void);
 
+/**
+ * @brief     This function serves to set ble_1M  mode of RF.
+ * @return	  none.
+ */
+void rf_set_ble_1M_mode(void);
 
 /**
  * @brief     This function serves to  set zigbee_125K  mode of RF.
@@ -1046,6 +1051,18 @@ _attribute_ram_code_sec_noinline_ void rf_start_brx  (void* addr, unsigned int t
  */
 _attribute_ram_code_sec_noinline_ void rf_start_btx (void* addr, unsigned int tick);
 
+/**
+ * @brief   	This function serves to set RF power through select the level index.
+ * @param[in]   idx 	 - The index of power level which you want to set.
+ * @return  	none.
+ */
+void rf_set_power_level_index(rf_power_level_index_e idx);
 
+/**
+ * @brief		This function do radio baseband reset
+ * @param 		none
+ * @return		none
+ */
+void rf_baseband_reset(void);
 
 #endif


### PR DESCRIPTION
Changelist:
* Add u64 type in types.h
* Wrap bool and wchar_t with corresponding #if due to types conflict during compilation
* Add getter for aes_data_buff
* Minor fix in rf_set_chn
* Add in pm.c
    * void pm_cal_32k_rc_offset (int offset_tick)
* Add in rf.c
    * void rf_set_ble_1M_mode(void)
    * void rf_set_ble_chn (signed char chn_num)
    * void rf_start_btx (void* addr, unsigned int tick)
    * void rf_start_brx  (void* addr, unsigned int tick)
    * void rf_start_stx2rx  (void* addr, unsigned int tick)
    * void rf_start_stx  (void* addr,  unsigned int tick)
    * void rf_baseband_reset(void)
    * void rf_set_power_level_index(rf_power_level_index_e idx)
