### PR TITLE
zephyr: check if BIT is defined before redefining

### DIFF
--- a/tlsr9/common/bit.h
+++ b/tlsr9/common/bit.h
@@ -43,7 +43,9 @@
 #ifndef BIT_H_
 #define BIT_H_
 
+#ifndef BIT
 #define BIT(n)                  		( 1<<(n))
+#endif
 #define BIT_MASK_LEN(len)       		(BIT(len)-1)
 #define BIT_RNG(s, e)  					(BIT_MASK_LEN((e)-(s)+1) << (s))
 


### PR DESCRIPTION
Normally `<sys/util_macro.h>` defines `BIT(n)` for Zephyr.

Required-by zephyrproject-rtos/zephyr#43987