### PR TITLE
hal: telink: Update Zephyr include paths

### DIFF
--- a/tlsr9/ble/vendor/controller/b91_bt.c
+++ b/tlsr9/ble/vendor/controller/b91_bt.c
@@ -16,7 +16,7 @@
  *
  *****************************************************************************/
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #undef irq_enable
 #undef irq_disable
 #undef ARRAY_SIZE

--- a/tlsr9/drivers/B91/ext_driver/ext_pm.h
+++ b/tlsr9/drivers/B91/ext_driver/ext_pm.h
@@ -19,7 +19,7 @@
 #ifndef DRIVERS_B91_DRIVER_EXT_EXT_PM_H_
 #define DRIVERS_B91_DRIVER_EXT_EXT_PM_H_
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #undef irq_enable
 #undef irq_disable
 #undef ARRAY_SIZE


### PR DESCRIPTION
Module include path are updated according to Zephyr main repository
includes location to avoid using LEGACY_INCLUDE_PATH during build
samples.