### PR TITLE
drivers: Disable BLE support

### DIFF
--- a/tlsr9/Kconfig
+++ b/tlsr9/Kconfig
@@ -1,4 +1,6 @@
 # Copyright (c) 2022 Telink Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-rsource "ble/vendor/controller/Kconfig"
+# Disabled, since the code doesn't build and the driver has been removed
+# from the Zephyr main tree.
+#rsource "ble/vendor/controller/Kconfig"


### PR DESCRIPTION
The code doesn't build. The main-tree HCI driver is about to removed, including the Kconfig option, which means that we can't have dependent Kconfig options in this tree.